### PR TITLE
Add default BAP roles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,14 @@ WORKDIR /usr/share/opensearch
 ENV PATH=/usr/share/opensearch/bin/:$PATH
 
 #
+# Add BAP roles to the security configuration
+#
+
+COPY security/bap_roles.yml /tmp/
+RUN cat /tmp/bap_roles.yml >> plugins/opensearch-security/securityconfig/roles.yml && \
+    rm /tmp/bap_roles.yml
+
+#
 # Plugins installation
 #
 # Secrets and keys can be configured once the container

--- a/security/bap_roles.yml
+++ b/security/bap_roles.yml
@@ -1,0 +1,63 @@
+bap_anonymous_access_role:
+  reserved: true
+  hidden: false
+  description: "Provides anonymous access to BAP dashboards"
+  cluster_permissions:
+    - "cluster_composite_ops_ro"
+  index_permissions:
+    - index_patterns:
+        - ".kibana"
+        - ".kibana_*"
+        - ".opensearch_dashboards"
+        - ".opensearch_dashboards_*"
+        - "bap_*"
+        - "grimoirelab_*"
+      allowed_actions:
+        - "read"
+
+bap_user_role:
+  reserved: true
+  hidden: false
+  description: "Provides minimum permisions to access BAP dashboards and tools"
+  cluster_permissions:
+    - "cluster_composite_ops_ro"
+  index_permissions:
+    - index_patterns:
+        - ".kibana"
+        - ".kibana_*"
+        - ".opensearch_dashboards"
+        - ".opensearch_dashboards_*"
+        - "bap_*"
+        - "grimoirelab_*"
+      allowed_actions:
+      - "read"
+
+bap_privileged_user_role:
+  reserved: true
+  hidden: false
+  description: "Provides BAP user permissions plus privileges to modify dashboards and visualizations"
+  cluster_permissions:
+    - "cluster_composite_ops"
+  index_permissions:
+    - index_patterns:
+      - "bap_*"
+      - "grimoirelab_*"
+      allowed_actions:
+      - "read"
+    - index_patterns:
+      - ".kibana"
+      - ".kibana_*"
+      - ".opensearch_dashboards"
+      - ".opensearch_dashboards_*"
+      allowed_actions:
+      - "read"
+      - "delete"
+      - "manage"
+      - "index"
+    - index_patterns:
+      - ".tasks"
+      - ".management-beats"
+      - "*:.tasks"
+      - "*:.management-beats"
+      allowed_actions:
+      - "indices_all"


### PR DESCRIPTION
This PR adds a set of predefined roles that define the user permissions in BAP. The idea is that every user in BAP will have assigned one of these roles, instead of the default ones defined by OpenSearch. We will simplify the number of roles needed and admins will understand better what each role does.

Take into account OpenSearch default roles are still available, so they can be used too.
