### PR TITLE
Add Mordred role

### DIFF
--- a/security/bap_roles.yml
+++ b/security/bap_roles.yml
@@ -1,3 +1,25 @@
+bap_mordred_role:
+  reserved: true
+  hidden: false
+  description: "Provides enough permisions to mordred to operate"
+  cluster_permissions:
+    - "cluster_composite_ops"
+    - "cluster_monitor"
+    - "indices:data/write/bulk"
+    - "indices:data/read/scroll/clear"
+  index_permissions:
+    - index_patterns:
+        - "bap_*"
+        - "grimoirelab_*"
+        - "custom_*"
+        - "c_*"
+      allowed_actions:
+        - "indices_all"
+    - index_patterns:
+        - "*"
+      allowed_actions:
+        - "manage_aliases"
+
 bap_anonymous_access_role:
   reserved: true
   hidden: false


### PR DESCRIPTION
The new role `bap_mordred_role` defines a role which can be used by mordred component to operate with OpenSearch. This new role defines the next permissions:

  - Access to BAP, GrimoireLab, and custom indices with the action group `indices_all`. This allows to run CRUD actions on these indices only. Mordred won't have access to any other index.
  - Manage of all the OpenSearch aliases with the action group `manage_aliases` that allows to create and remove alises, and link these aliases to existing indices.
  - Monitor indices with the actiong group `cluster_monitor`.
  - Bulk operations with indices and aliases thanks to `cluster_composite_ops` action group and and 'indices:data/write/bulk' permission.
  - Scroll operarions are also used by mordred so we add 'indices:data/read/scroll/clear' permission.